### PR TITLE
Gristlabs branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "files": [
     "bin",
-    "dist/bundle.esm.js"
+    "dist"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "moment-guess",
-  "version": "1.2.4",
+  "name": "@gristlabs/moment-guess",
+  "version": "1.2.4-grist.1",
   "description": "A utility package for guessing date's format",
   "homepage": "https://github.com/apoorv-mishra/moment-guess#readme",
   "repository": {


### PR DESCRIPTION
To use until https://github.com/apoorv-mishra/moment-guess/pull/22 is merged, to prevent ugly build warnings.

I can't seem to publish this:

```
$ npm publish
npm notice 
npm notice 📦  @gristlabs/moment-guess@1.2.4-grist.1
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE               
npm notice 85.9kB bin/bundle.cmd.js     
npm notice 34.5kB dist/bundle.esm.js    
npm notice 34.6kB dist/bundle.js        
npm notice 1.1kB  package.json          
npm notice 72.5kB dist/bundle.esm.js.map
npm notice 72.5kB dist/bundle.js.map    
npm notice 5.1kB  README.md             
npm notice === Tarball Details === 
npm notice name:          @gristlabs/moment-guess                 
npm notice version:       1.2.4-grist.1                           
npm notice package size:  49.0 kB                                 
npm notice unpacked size: 307.3 kB                                
npm notice shasum:        b15daba4b9d1e1d4e4fbafbddc0be8dddc21dde3
npm notice integrity:     sha512-emosrHFak1JYE[...]sm0+2KANaNLdg==
npm notice total files:   8                                       
npm notice 
This operation requires a one-time password.
Enter OTP: 439190
npm ERR! code E402
npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@gristlabs%2fmoment-guess - You must sign up for private packages

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/alex/.npm/_logs/2022-02-21T12_22_25_635Z-debug.log
```